### PR TITLE
Change DNS Records order

### DIFF
--- a/TechnitiumLibrary.Net/Dns/ResourceRecords/DnsResourceRecord.cs
+++ b/TechnitiumLibrary.Net/Dns/ResourceRecords/DnsResourceRecord.cs
@@ -561,13 +561,22 @@ namespace TechnitiumLibrary.Net.Dns.ResourceRecords
 
         public int CompareTo(DnsResourceRecord other)
         {
-            int value;
+            //Compare names, starting from tld, moving left
+            var thisSplit = _name.Split('.');
+            var otherSplit = other._name.Split('.');
+            for (int i = 1; i <= Math.Min(thisSplit.Length, otherSplit.Length); i++)
+            {
+                if (thisSplit[^i] == "*")
+                    return -1;
+                if (otherSplit[^i] == "*")
+                    return 1;
 
-            value = _name.CompareTo(other._name);
-            if (value != 0)
-                return value;
+                var compare = thisSplit[^i].CompareTo(otherSplit[^i]);
+                if (compare != 0)
+                    return compare;
+            }
 
-            value = _type.CompareTo(other._type);
+            int value = _type.CompareTo(other._type);
             if (value != 0)
                 return value;
 


### PR DESCRIPTION
Order DNS records working from TLD to the left, like e.g. azure DNS does it.
This sorting is better because it moves subdomain just after to parent one.
Before:
<img width="200" alt="image" src="https://user-images.githubusercontent.com/2399369/148649631-6fe69d37-220f-4d2c-8447-f1fd011f9958.png">
After:
<img width="200" alt="image" src="https://user-images.githubusercontent.com/2399369/148649403-18785974-1648-4098-901c-46be16f2419c.png">
