### PR TITLE
Fixed issue where secondary AXFR would not work on older windows

### DIFF
--- a/TechnitiumLibrary.Net/Dns/ClientConnection/TcpClientConnection.cs
+++ b/TechnitiumLibrary.Net/Dns/ClientConnection/TcpClientConnection.cs
@@ -382,7 +382,7 @@ namespace TechnitiumLibrary.Net.Dns.ClientConnection
 
                     _lastResponse = response;
 
-                    if ((_lastResponse.Answer.Count == 0) || (_lastResponse.Answer[_lastResponse.Answer.Count - 1].Type == DnsResourceRecordType.SOA))
+                    if ((_lastResponse.Answer.Count == 0) || (_lastResponse.Answer[_lastResponse.Answer.Count - 1].Type == DnsResourceRecordType.SOA && _firstResponse != _lastResponse))
                     {
                         //found last response
                         _stopwatch.Stop();

--- a/TechnitiumLibrary.Net/Dns/ClientConnection/TcpClientConnection.cs
+++ b/TechnitiumLibrary.Net/Dns/ClientConnection/TcpClientConnection.cs
@@ -375,14 +375,20 @@ namespace TechnitiumLibrary.Net.Dns.ClientConnection
             {
                 if (_isZoneTransferRequest)
                 {
+                    var firstResponse = false;
                     if (_firstResponse is null)
+                    {
                         _firstResponse = response;
+                        firstResponse = true;
+                    }
                     else
+                    {
                         _lastResponse.NextDatagram = response;
+                    }
 
                     _lastResponse = response;
 
-                    if ((_lastResponse.Answer.Count == 0) || (_lastResponse.Answer[_lastResponse.Answer.Count - 1].Type == DnsResourceRecordType.SOA && _firstResponse != _lastResponse))
+                    if ((_lastResponse.Answer.Count == 0) || (_lastResponse.Answer[_lastResponse.Answer.Count - 1].Type == DnsResourceRecordType.SOA && (_lastResponse.Answer.Count > 1 || !firstResponse)))
                     {
                         //found last response
                         _stopwatch.Stop();


### PR DESCRIPTION
Older versions of windows send SOA as first message in AXFR, causing zone transfer to fail as only 1 message was read.