### PR TITLE
TryParse must fail on empty string, whitespace and null strings

### DIFF
--- a/TechnitiumLibrary.Net/DomainEndPoint.cs
+++ b/TechnitiumLibrary.Net/DomainEndPoint.cs
@@ -61,6 +61,12 @@ namespace TechnitiumLibrary.Net
 
         public static bool TryParse(string value, out DomainEndPoint ep)
         {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                ep = null;
+                return false;
+            }
+
             string[] parts = value.Split(':');
             if (parts.Length > 2)
             {

--- a/TechnitiumLibrary.Net/NetworkAddress.cs
+++ b/TechnitiumLibrary.Net/NetworkAddress.cs
@@ -1,7 +1,6 @@
 ﻿/*
 Technitium Library
 Copyright (C) 2024  Shreyas Zare (shreyas@technitium.com)
-Copyright (C) 2026  Zafer Balkan (zafer@zaferbalkan.com)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/TechnitiumLibrary.Net/NetworkAddress.cs
+++ b/TechnitiumLibrary.Net/NetworkAddress.cs
@@ -1,6 +1,7 @@
 ﻿/*
 Technitium Library
 Copyright (C) 2024  Shreyas Zare (shreyas@technitium.com)
+Copyright (C) 2026  Zafer Balkan (zafer@zaferbalkan.com)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
As the title says "TryParse must fail on empty string, whitespace and null strings", but it throws exception on `string.Split()` method. This case can be handled easily with a guard clause.