### PR TITLE
TryParseReverseDomain should fail on invalid IPv4 addresses such as one octet less or more.

### DIFF
--- a/TechnitiumLibrary.Net/IPAddressExtensions.cs
+++ b/TechnitiumLibrary.Net/IPAddressExtensions.cs
@@ -1,7 +1,6 @@
 ﻿/*
 Technitium Library
 Copyright (C) 2025  Shreyas Zare (shreyas@technitium.com)
-Copyright (C) 2026  Zafer Balkan (zafer@zaferbalkan.com)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/TechnitiumLibrary.Net/IPAddressExtensions.cs
+++ b/TechnitiumLibrary.Net/IPAddressExtensions.cs
@@ -1,6 +1,7 @@
 ﻿/*
 Technitium Library
 Copyright (C) 2025  Shreyas Zare (shreyas@technitium.com)
+Copyright (C) 2026  Zafer Balkan (zafer@zaferbalkan.com)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/TechnitiumLibrary.Net/IPAddressExtensions.cs
+++ b/TechnitiumLibrary.Net/IPAddressExtensions.cs
@@ -444,6 +444,14 @@ namespace TechnitiumLibrary.Net
                 //192.168.10.1
 
                 string[] parts = ptrDomain.Split('.');
+
+                // Expecting 6 parts: 4 octets + in-addr + arpa
+                if (parts.Length != 6)
+                {
+                    address = null;
+                    return false;
+                }
+
                 Span<byte> buffer = stackalloc byte[4];
 
                 for (int i = 0, j = parts.Length - 3; (i < 4) && (j > -1); i++, j--)


### PR DESCRIPTION
Solves https://github.com/TechnitiumSoftware/TechnitiumLibrary/issues/41:


>When one ore more octets are missing the `Span<byte> buffer = stackalloc byte[4];` line fills it with zeroes, therefore covers the error.
>
>When one or more octets are extra, `for (int i = 0, j = parts.Length - 3; (i < 4) && (j > -1); i++, j--)` loop covers as it ignores the extras.

I added an explicit guard clause for IPv4 addresses.