### PR TITLE
Added a catch block for json parser as a guard clause

### DIFF
--- a/TechnitiumLibrary.Net/Dns/ResourceRecords/DnsApplicationRecordData.cs
+++ b/TechnitiumLibrary.Net/Dns/ResourceRecords/DnsApplicationRecordData.cs
@@ -43,8 +43,15 @@ namespace TechnitiumLibrary.Net.Dns.ResourceRecords
         {
             if (data.StartsWith('{') || data.StartsWith('['))
             {
-                using (JsonDocument jsonDocument = JsonDocument.Parse(data))
-                { }
+                try
+                {
+                    using (JsonDocument jsonDocument = JsonDocument.Parse(data))
+                    { }
+                }
+                catch (JsonException)
+                {
+                    throw new ArgumentException("Data is not a valid JSON string.", nameof(data));
+                }
             }
 
             _appName = appName;

--- a/TechnitiumLibrary.Net/Dns/ResourceRecords/DnsApplicationRecordData.cs
+++ b/TechnitiumLibrary.Net/Dns/ResourceRecords/DnsApplicationRecordData.cs
@@ -45,8 +45,7 @@ namespace TechnitiumLibrary.Net.Dns.ResourceRecords
             {
                 try
                 {
-                    using (JsonDocument jsonDocument = JsonDocument.Parse(data))
-                    { }
+                    _ = JsonDocument.Parse(data);
                 }
                 catch (JsonException)
                 {


### PR DESCRIPTION
Solves https://github.com/TechnitiumSoftware/TechnitiumLibrary/issues/43

> Without a catch block, `DnsApplicationRecordData` constructor throws `System.Text.Json.JsonReaderException`. To making the behavior explicit a try-catch clause with `System.ArgumentException`, is needed.

It is not a blocker but just making the exceptions more explicit.