### PR TITLE
Added support for DNS cookies (RFC 7873/9018, and partially BCP 38)

### DIFF
--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
@@ -1,0 +1,174 @@
+﻿/*
+Technitium Library
+Copyright(C) 2026  Shreyas Zare(shreyas @technitium.com)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace TechnitiumLibrary.Net.Dns.EDnsOptions
+{
+    /// <summary>
+    /// RFC 7873 DNS COOKIE EDNS option.
+    /// Option data:
+    /// - Client cookie: 8 bytes (MUST)
+    /// - Server cookie: 0 or 8-32 bytes (MAY)
+    /// Total option data length: 8 OR 16-40 bytes.
+    /// </summary>
+    public class EDnsCookieOptionData : EDnsOptionData
+    {
+        #region variables
+
+        public const int CLIENT_COOKIE_LENGTH = 8;
+        public const int SERVER_COOKIE_MAX_LENGTH = 32;
+        public const int SERVER_COOKIE_MIN_LENGTH = 8;
+        byte[] _clientCookie;
+        byte[] _serverCookie; // null means absent (client-cookie-only) 
+
+        #endregion
+
+        #region constructor
+
+        public EDnsCookieOptionData(byte[] clientCookie, byte[] serverCookie = null)
+        {
+            ArgumentNullException.ThrowIfNull(clientCookie);
+
+            if (clientCookie.Length != CLIENT_COOKIE_LENGTH)
+                throw new ArgumentException("Client cookie must be 8 bytes.", nameof(clientCookie));
+
+            if (serverCookie is not null &&
+                (serverCookie.Length < SERVER_COOKIE_MIN_LENGTH || serverCookie.Length > SERVER_COOKIE_MAX_LENGTH))
+                throw new ArgumentException("Server cookie must be 8-32 bytes.", nameof(serverCookie));
+
+            _clientCookie = (byte[])clientCookie.Clone();
+            _serverCookie = serverCookie is null ? null : (byte[])serverCookie.Clone();
+        }
+
+        /// <summary>
+        /// Parsing ctor. The stream is positioned at OPTION-LENGTH (immediately after OPTION-CODE),
+        /// because EDnsOption(Stream) already read OPTION-CODE.
+        /// </summary>
+        public EDnsCookieOptionData(Stream s)
+            : base(s)
+        { }
+
+        #endregion
+
+        #region protected
+
+        protected override void ReadOptionData(Stream s)
+        {
+            // _length is OPTION-LENGTH (bytes of option data).
+            if (_length < CLIENT_COOKIE_LENGTH)
+                throw new InvalidDataException($"Invalid COOKIE option length: {_length} bytes");
+
+            int serverLen = _length - CLIENT_COOKIE_LENGTH;
+
+            // Valid serverLen: 0 OR 8..32.
+            if (serverLen != 0 && (serverLen < SERVER_COOKIE_MIN_LENGTH || serverLen > SERVER_COOKIE_MAX_LENGTH))
+                throw new InvalidDataException($"Invalid server cookie length: {serverLen} bytes. Valid lengths are exactly 0 bytes, or between {SERVER_COOKIE_MIN_LENGTH} and {SERVER_COOKIE_MAX_LENGTH} bytes.");
+
+            _clientCookie = new byte[CLIENT_COOKIE_LENGTH];
+            s.ReadExactly(_clientCookie);
+
+            if (serverLen == 0)
+            {
+                _serverCookie = null;
+                return;
+            }
+
+            _serverCookie = new byte[serverLen];
+            s.ReadExactly(_serverCookie);
+        }
+
+        protected override void WriteOptionData(Stream s)
+        {
+            s.Write(_clientCookie);
+
+            if (_serverCookie is not null)
+                s.Write(_serverCookie);
+        }
+
+        #endregion
+
+        #region public
+
+        public bool Equals(EDnsCookieOptionData other)
+        {
+            if (other is null)
+                return false;
+
+            if (!_clientCookie.AsSpan().SequenceEqual(other._clientCookie))
+                return false;
+
+            if (_serverCookie is null && other._serverCookie is null)
+                return true;
+
+            if (_serverCookie is null || other._serverCookie is null)
+                return false;
+
+            return _serverCookie.AsSpan().SequenceEqual(other._serverCookie);
+        }
+
+        public override bool Equals(object obj) => Equals(obj as EDnsCookieOptionData);
+
+        public override int GetHashCode()
+        {
+            HashCode hash = new();
+
+            foreach (byte b in _clientCookie)
+                hash.Add(b);
+
+            if (_serverCookie is not null)
+                foreach (byte b in _serverCookie)
+                    hash.Add(b);
+
+            return hash.ToHashCode();
+        }
+
+        public override void SerializeTo(Utf8JsonWriter writer)
+        {
+            writer.WriteStartObject();
+
+            writer.WriteString(nameof(ClientCookie), Convert.ToHexString(_clientCookie));
+
+            if (_serverCookie is not null)
+                writer.WriteString(nameof(ServerCookie), Convert.ToHexString(_serverCookie));
+
+            writer.WriteEndObject();
+        }
+
+        public override string ToString()
+        {
+            if (_serverCookie is null)
+                return $"COOKIE client={Convert.ToHexString(_clientCookie)}";
+
+            return $"COOKIE client={Convert.ToHexString(_clientCookie)} server={Convert.ToHexString(_serverCookie)}";
+        }
+
+        #endregion
+
+        #region properties
+        public ReadOnlySpan<byte> ClientCookie => _clientCookie;
+        public bool HasServerCookie => _serverCookie is not null;
+        public ReadOnlySpan<byte> ServerCookie => _serverCookie is null ? ReadOnlySpan<byte>.Empty : _serverCookie;
+        public override int UncompressedLength => CLIENT_COOKIE_LENGTH + (_serverCookie?.Length ?? 0);
+
+        #endregion
+    }
+}

--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
@@ -30,19 +30,19 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
     /// - Server cookie: 0 or 8-32 bytes (MAY)
     /// Total option data length: 8 OR 16-40 bytes.
     /// </summary>
-    public sealed class EDnsCookieOptionData : EDnsOptionData, IEquatable<EDnsCookieOptionData>
+    public class EDnsCookieOptionData : EDnsOptionData
     {
+        #region variables
+
         public const int CLIENT_COOKIE_LENGTH = 8;
-        public const int SERVER_COOKIE_MIN_LENGTH = 8;
         public const int SERVER_COOKIE_MAX_LENGTH = 32;
-
+        public const int SERVER_COOKIE_MIN_LENGTH = 8;
         byte[] _clientCookie;
-        byte[] _serverCookie; // null means absent (client-cookie-only)
+        byte[] _serverCookie; // null means absent (client-cookie-only) 
 
-        public ReadOnlySpan<byte> ClientCookie => _clientCookie;
-        public ReadOnlySpan<byte> ServerCookie => _serverCookie is null ? ReadOnlySpan<byte>.Empty : _serverCookie;
+        #endregion
 
-        public bool HasServerCookie => _serverCookie is not null;
+        #region constructor
 
         public EDnsCookieOptionData(byte[] clientCookie, byte[] serverCookie = null)
         {
@@ -67,7 +67,9 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
             : base(s)
         { }
 
-        public override int UncompressedLength => CLIENT_COOKIE_LENGTH + (_serverCookie?.Length ?? 0);
+        #endregion
+
+        #region protected
 
         protected override void ReadOptionData(Stream s)
         {
@@ -102,25 +104,9 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
                 s.Write(_serverCookie);
         }
 
-        public override void SerializeTo(Utf8JsonWriter writer)
-        {
-            writer.WriteStartObject();
+        #endregion
 
-            writer.WriteString("client", Convert.ToHexString(_clientCookie));
-
-            if (_serverCookie is not null)
-                writer.WriteString("server", Convert.ToHexString(_serverCookie));
-
-            writer.WriteEndObject();
-        }
-
-        public override string ToString()
-        {
-            if (_serverCookie is null)
-                return $"COOKIE client={Convert.ToHexString(_clientCookie)}";
-
-            return $"COOKIE client={Convert.ToHexString(_clientCookie)} server={Convert.ToHexString(_serverCookie)}";
-        }
+        #region public
 
         public bool Equals(EDnsCookieOptionData other)
         {
@@ -154,5 +140,35 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
 
             return hash.ToHashCode();
         }
+
+        public override void SerializeTo(Utf8JsonWriter writer)
+        {
+            writer.WriteStartObject();
+
+            writer.WriteString("client", Convert.ToHexString(_clientCookie));
+
+            if (_serverCookie is not null)
+                writer.WriteString("server", Convert.ToHexString(_serverCookie));
+
+            writer.WriteEndObject();
+        }
+
+        public override string ToString()
+        {
+            if (_serverCookie is null)
+                return $"COOKIE client={Convert.ToHexString(_clientCookie)}";
+
+            return $"COOKIE client={Convert.ToHexString(_clientCookie)} server={Convert.ToHexString(_serverCookie)}";
+        }
+
+        #endregion
+
+        #region properties
+        public ReadOnlySpan<byte> ClientCookie => _clientCookie;
+        public bool HasServerCookie => _serverCookie is not null;
+        public ReadOnlySpan<byte> ServerCookie => _serverCookie is null ? ReadOnlySpan<byte>.Empty : _serverCookie;
+        public override int UncompressedLength => CLIENT_COOKIE_LENGTH + (_serverCookie?.Length ?? 0);
+
+        #endregion
     }
 }

--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.IO;
+using System.Text.Json;
+
+namespace TechnitiumLibrary.Net.Dns.EDnsOptions
+{
+    /// <summary>
+    /// RFC 7873 DNS COOKIE EDNS option.
+    /// Option data:
+    /// - Client cookie: 8 bytes (MUST)
+    /// - Server cookie: 0 or 8-32 bytes (MAY)
+    /// Total option data length: 8 OR 16-40 bytes.
+    /// </summary>
+    public sealed class EDnsCookieOptionData : EDnsOptionData, IEquatable<EDnsCookieOptionData>
+    {
+        public const int CLIENT_COOKIE_LENGTH = 8;
+        public const int SERVER_COOKIE_MIN_LENGTH = 8;
+        public const int SERVER_COOKIE_MAX_LENGTH = 32;
+
+        byte[] _clientCookie;
+        byte[] _serverCookie; // null means absent (client-cookie-only)
+
+        public ReadOnlySpan<byte> ClientCookie => _clientCookie;
+        public ReadOnlySpan<byte> ServerCookie => _serverCookie is null ? ReadOnlySpan<byte>.Empty : _serverCookie;
+
+        public bool HasServerCookie => _serverCookie is not null;
+
+        public EDnsCookieOptionData(byte[] clientCookie, byte[] serverCookie = null)
+        {
+            ArgumentNullException.ThrowIfNull(clientCookie);
+
+            if (clientCookie.Length != CLIENT_COOKIE_LENGTH)
+                throw new ArgumentException("Client cookie must be 8 bytes.", nameof(clientCookie));
+
+            if (serverCookie is not null &&
+                (serverCookie.Length < SERVER_COOKIE_MIN_LENGTH || serverCookie.Length > SERVER_COOKIE_MAX_LENGTH))
+                throw new ArgumentException("Server cookie must be 8-32 bytes.", nameof(serverCookie));
+
+            _clientCookie = (byte[])clientCookie.Clone();
+            _serverCookie = serverCookie is null ? null : (byte[])serverCookie.Clone();
+        }
+
+        /// <summary>
+        /// Parsing ctor. The stream is positioned at OPTION-LENGTH (immediately after OPTION-CODE),
+        /// because EDnsOption(Stream) already read OPTION-CODE.
+        /// </summary>
+        public EDnsCookieOptionData(Stream s)
+            : base(s)
+        { }
+
+        public override int UncompressedLength => CLIENT_COOKIE_LENGTH + (_serverCookie?.Length ?? 0);
+
+        protected override void ReadOptionData(Stream s)
+        {
+            // _length is OPTION-LENGTH (bytes of option data).
+            if (_length < CLIENT_COOKIE_LENGTH)
+                throw new InvalidDataException($"Invalid COOKIE option length: {_length} bytes");
+
+            int serverLen = _length - CLIENT_COOKIE_LENGTH;
+
+            // Valid serverLen: 0 OR 8..32.
+            if (serverLen != 0 && (serverLen < SERVER_COOKIE_MIN_LENGTH || serverLen > SERVER_COOKIE_MAX_LENGTH))
+                throw new InvalidDataException($"Invalid server cookie length: {serverLen} bytes");
+
+            _clientCookie = new byte[CLIENT_COOKIE_LENGTH];
+            s.ReadExactly(_clientCookie);
+
+            if (serverLen == 0)
+            {
+                _serverCookie = null;
+                return;
+            }
+
+            _serverCookie = new byte[serverLen];
+            s.ReadExactly(_serverCookie);
+        }
+
+        protected override void WriteOptionData(Stream s)
+        {
+            s.Write(_clientCookie);
+
+            if (_serverCookie is not null)
+                s.Write(_serverCookie);
+        }
+
+        public override void SerializeTo(Utf8JsonWriter writer)
+        {
+            writer.WriteStartObject();
+
+            writer.WriteString("client", Convert.ToHexString(_clientCookie));
+
+            if (_serverCookie is not null)
+                writer.WriteString("server", Convert.ToHexString(_serverCookie));
+
+            writer.WriteEndObject();
+        }
+
+        public override string ToString()
+        {
+            if (_serverCookie is null)
+                return $"COOKIE client={Convert.ToHexString(_clientCookie)}";
+
+            return $"COOKIE client={Convert.ToHexString(_clientCookie)} server={Convert.ToHexString(_serverCookie)}";
+        }
+
+        public bool Equals(EDnsCookieOptionData other)
+        {
+            if (other is null)
+                return false;
+
+            if (!_clientCookie.AsSpan().SequenceEqual(other._clientCookie))
+                return false;
+
+            if (_serverCookie is null && other._serverCookie is null)
+                return true;
+
+            if (_serverCookie is null || other._serverCookie is null)
+                return false;
+
+            return _serverCookie.AsSpan().SequenceEqual(other._serverCookie);
+        }
+
+        public override bool Equals(object obj) => Equals(obj as EDnsCookieOptionData);
+
+        public override int GetHashCode()
+        {
+            HashCode hash = new();
+
+            foreach (byte b in _clientCookie)
+                hash.Add(b);
+
+            if (_serverCookie is not null)
+                foreach (byte b in _serverCookie)
+                    hash.Add(b);
+
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
@@ -79,7 +79,7 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
 
             // Valid serverLen: 0 OR 8..32.
             if (serverLen != 0 && (serverLen < SERVER_COOKIE_MIN_LENGTH || serverLen > SERVER_COOKIE_MAX_LENGTH))
-                throw new InvalidDataException($"Invalid server cookie length: {serverLen} bytes");
+                throw new InvalidDataException($"Invalid server cookie length: {serverLen} bytes. Valid lengths are exactly 0 bytes, or between {SERVER_COOKIE_MIN_LENGTH} and {SERVER_COOKIE_MAX_LENGTH} bytes.");
 
             _clientCookie = new byte[CLIENT_COOKIE_LENGTH];
             s.ReadExactly(_clientCookie);

--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
@@ -1,4 +1,23 @@
-﻿using System;
+﻿/*
+Technitium Library
+Copyright(C) 2026  Shreyas Zare(shreyas @technitium.com)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+using System;
 using System.IO;
 using System.Text.Json;
 

--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
@@ -145,10 +145,10 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         {
             writer.WriteStartObject();
 
-            writer.WriteString("client", Convert.ToHexString(_clientCookie));
+            writer.WriteString("ClientCookie", Convert.ToHexString(_clientCookie));
 
             if (_serverCookie is not null)
-                writer.WriteString("server", Convert.ToHexString(_serverCookie));
+                writer.WriteString("ServerCookie", Convert.ToHexString(_serverCookie));
 
             writer.WriteEndObject();
         }

--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
@@ -39,6 +39,7 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         public const int SERVER_COOKIE_MIN_LENGTH = 8;
         byte[] _clientCookie;
         byte[] _serverCookie; //null means absent (client-cookie-only)
+        byte[] _malformedData; //preserved wire data for server-side RFC 7873 FORMERR handling
 
         #endregion
 
@@ -73,15 +74,18 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
 
         protected override void ReadOptionData(Stream s)
         {
-            // _length is OPTION-LENGTH (bytes of option data).
-            if (_length < CLIENT_COOKIE_LENGTH)
-                throw new InvalidDataException($"Invalid COOKIE option length: {_length} bytes");
-
+            // RFC 7873 §5.2.2 requires the server to return FORMERR for a malformed
+            // COOKIE length. Preserve and consume the malformed payload so that the
+            // complete DNS datagram reaches the server's COOKIE classifier instead of
+            // aborting EDNS parsing and surfacing as a transport exception.
             int serverLen = _length - CLIENT_COOKIE_LENGTH;
-
-            // Valid serverLen: 0 OR 8..32.
-            if (serverLen != 0 && (serverLen < SERVER_COOKIE_MIN_LENGTH || serverLen > SERVER_COOKIE_MAX_LENGTH))
-                throw new InvalidDataException($"Invalid server cookie length: {serverLen} bytes. Valid lengths are exactly 0 bytes, or between {SERVER_COOKIE_MIN_LENGTH} and {SERVER_COOKIE_MAX_LENGTH} bytes.");
+            if (_length < CLIENT_COOKIE_LENGTH ||
+                (serverLen != 0 && (serverLen < SERVER_COOKIE_MIN_LENGTH || serverLen > SERVER_COOKIE_MAX_LENGTH)))
+            {
+                _malformedData = new byte[_length];
+                s.ReadExactly(_malformedData);
+                return;
+            }
 
             _clientCookie = new byte[CLIENT_COOKIE_LENGTH];
             s.ReadExactly(_clientCookie);
@@ -98,6 +102,12 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
 
         protected override void WriteOptionData(Stream s)
         {
+            if (_malformedData is not null)
+            {
+                s.Write(_malformedData);
+                return;
+            }
+
             s.Write(_clientCookie);
 
             if (_serverCookie is not null)
@@ -115,6 +125,9 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
 
             if (ReferenceEquals(this, other))
                 return true;
+
+            if (_malformedData is not null || other._malformedData is not null)
+                return _malformedData is not null && other._malformedData is not null && _malformedData.AsSpan().SequenceEqual(other._malformedData);
 
             if (!_clientCookie.AsSpan().SequenceEqual(other._clientCookie))
                 return false;
@@ -134,6 +147,13 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         {
             HashCode hash = new();
 
+            if (_malformedData is not null)
+            {
+                foreach (byte b in _malformedData)
+                    hash.Add(b);
+                return hash.ToHashCode();
+            }
+
             foreach (byte b in _clientCookie)
                 hash.Add(b);
 
@@ -148,6 +168,13 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         {
             writer.WriteStartObject();
 
+            if (_malformedData is not null)
+            {
+                writer.WriteString("MalformedData", Convert.ToHexString(_malformedData));
+                writer.WriteEndObject();
+                return;
+            }
+
             writer.WriteString(nameof(ClientCookie), Convert.ToHexString(_clientCookie));
 
             if (_serverCookie is not null)
@@ -158,6 +185,9 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
 
         public override string ToString()
         {
+            if (_malformedData is not null)
+                return $"COOKIE malformed length={_malformedData.Length}";
+
             if (_serverCookie is null)
                 return $"COOKIE client={Convert.ToHexString(_clientCookie)}";
 
@@ -168,13 +198,15 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
 
         #region properties
 
-        public ReadOnlySpan<byte> ClientCookie => _clientCookie;
+        public bool IsMalformed => _malformedData is not null;
+
+        public ReadOnlySpan<byte> ClientCookie => _clientCookie is null ? ReadOnlySpan<byte>.Empty : _clientCookie;
 
         public bool HasServerCookie => _serverCookie is not null;
 
         public ReadOnlySpan<byte> ServerCookie => _serverCookie is null ? ReadOnlySpan<byte>.Empty : _serverCookie;
 
-        public override int UncompressedLength => CLIENT_COOKIE_LENGTH + (_serverCookie?.Length ?? 0);
+        public override int UncompressedLength => _malformedData?.Length ?? (CLIENT_COOKIE_LENGTH + (_serverCookie?.Length ?? 0));
 
         #endregion
     }

--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
@@ -129,16 +129,10 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
             if (_malformedData is not null || other._malformedData is not null)
                 return _malformedData is not null && other._malformedData is not null && _malformedData.AsSpan().SequenceEqual(other._malformedData);
 
-            if (!_clientCookie.AsSpan().SequenceEqual(other._clientCookie))
-                return false;
-
-            if (_serverCookie is null && other._serverCookie is null)
-                return true;
-
-            if (_serverCookie is null || other._serverCookie is null)
-                return false;
-
-            return _serverCookie.AsSpan().SequenceEqual(other._serverCookie);
+            // A server cookie is either absent or 8-32 bytes - never a zero-length array -
+            // so mapping null to an empty span decides the absent cases correctly too.
+            return _clientCookie.AsSpan().SequenceEqual(other._clientCookie) &&
+                _serverCookie.AsSpan().SequenceEqual(other._serverCookie);
         }
 
         public override bool Equals(object obj) => Equals(obj as EDnsCookieOptionData);
@@ -147,19 +141,19 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         {
             HashCode hash = new();
 
+            // AddBytes keeps the byte order significant. CollectionExtensions.GetArrayHashCode
+            // would read better here but XORs its elements, which collides heavily on the
+            // short, near-sequential byte runs cookies are made of.
             if (_malformedData is not null)
             {
-                foreach (byte b in _malformedData)
-                    hash.Add(b);
+                hash.AddBytes(_malformedData);
                 return hash.ToHashCode();
             }
 
-            foreach (byte b in _clientCookie)
-                hash.Add(b);
+            hash.AddBytes(_clientCookie);
 
-            if (_serverCookie is not null)
-                foreach (byte b in _serverCookie)
-                    hash.Add(b);
+            // A null server cookie converts to an empty span, which contributes nothing.
+            hash.AddBytes(_serverCookie);
 
             return hash.ToHashCode();
         }
@@ -188,10 +182,9 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
             if (_malformedData is not null)
                 return $"COOKIE malformed length={_malformedData.Length}";
 
-            if (_serverCookie is null)
-                return $"COOKIE client={Convert.ToHexString(_clientCookie)}";
+            string cookie = $"COOKIE client={Convert.ToHexString(_clientCookie)}";
 
-            return $"COOKIE client={Convert.ToHexString(_clientCookie)} server={Convert.ToHexString(_serverCookie)}";
+            return _serverCookie is null ? cookie : $"{cookie} server={Convert.ToHexString(_serverCookie)}";
         }
 
         #endregion
@@ -200,11 +193,11 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
 
         public bool IsMalformed => _malformedData is not null;
 
-        public ReadOnlySpan<byte> ClientCookie => _clientCookie is null ? ReadOnlySpan<byte>.Empty : _clientCookie;
+        public ReadOnlySpan<byte> ClientCookie => _clientCookie;
 
         public bool HasServerCookie => _serverCookie is not null;
 
-        public ReadOnlySpan<byte> ServerCookie => _serverCookie is null ? ReadOnlySpan<byte>.Empty : _serverCookie;
+        public ReadOnlySpan<byte> ServerCookie => _serverCookie;
 
         public override int UncompressedLength => _malformedData?.Length ?? (CLIENT_COOKIE_LENGTH + (_serverCookie?.Length ?? 0));
 

--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsCookieOptionData.cs
@@ -1,6 +1,6 @@
 ﻿/*
 Technitium Library
-Copyright(C) 2026  Shreyas Zare(shreyas @technitium.com)
+Copyright (C) 2026  Shreyas Zare (shreyas@technitium.com)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -38,7 +38,7 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         public const int SERVER_COOKIE_MAX_LENGTH = 32;
         public const int SERVER_COOKIE_MIN_LENGTH = 8;
         byte[] _clientCookie;
-        byte[] _serverCookie; // null means absent (client-cookie-only) 
+        byte[] _serverCookie; //null means absent (client-cookie-only)
 
         #endregion
 
@@ -113,6 +113,9 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
             if (other is null)
                 return false;
 
+            if (ReferenceEquals(this, other))
+                return true;
+
             if (!_clientCookie.AsSpan().SequenceEqual(other._clientCookie))
                 return false;
 
@@ -164,9 +167,13 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         #endregion
 
         #region properties
+
         public ReadOnlySpan<byte> ClientCookie => _clientCookie;
+
         public bool HasServerCookie => _serverCookie is not null;
+
         public ReadOnlySpan<byte> ServerCookie => _serverCookie is null ? ReadOnlySpan<byte>.Empty : _serverCookie;
+
         public override int UncompressedLength => CLIENT_COOKIE_LENGTH + (_serverCookie?.Length ?? 0);
 
         #endregion

--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsOption.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsOption.cs
@@ -153,12 +153,12 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
                 jsonWriter.WritePropertyName(nameof(Data));
                 _data.SerializeTo(jsonWriter);
             }
-
+            jsonWriter.WriteEndObject();
         }
 
         #endregion
 
-            #region properties
+        #region properties
 
         public EDnsOptionCode Code
         { get { return _code; } }

--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsOption.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsOption.cs
@@ -78,6 +78,10 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
                     _data = new EDnsExtendedDnsErrorOptionData(s);
                     break;
 
+                case EDnsOptionCode.COOKIE:
+                    _data = new EDnsCookieOptionData(s);
+                    break;
+
                 default:
                     _data = new EDnsUnknownOptionData(s);
                     break;
@@ -92,6 +96,14 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         {
             DnsDatagram.WriteUInt16NetworkOrder((ushort)_code, s);
 
+            // OPTION-LENGTH=0 is valid; represent with null data.
+            if (_data is null)
+            {
+                DnsDatagram.WriteUInt16NetworkOrder(0, s);
+                return;
+            }
+
+            // EDnsOptionData.WriteTo writes OPTION-LENGTH + option bytes.
             _data.WriteTo(s);
         }
 
@@ -128,18 +140,25 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         {
             jsonWriter.WriteStartObject();
 
-            jsonWriter.WriteString("Code", _code.ToString());
-            jsonWriter.WriteString("Length", _data.Length + " bytes");
+            jsonWriter.WriteString(nameof(Code), _code.ToString());
 
-            jsonWriter.WritePropertyName("Data");
-            _data.SerializeTo(jsonWriter);
+            if (_data is null)
+            {
+                jsonWriter.WriteString("Length", "0 bytes");
+                jsonWriter.WriteNull(nameof(Data));
+            }
+            else
+            {
+                jsonWriter.WriteString("Length", _data.Length + " bytes");
+                jsonWriter.WritePropertyName(nameof(Data));
+                _data.SerializeTo(jsonWriter);
+            }
 
-            jsonWriter.WriteEndObject();
         }
 
         #endregion
 
-        #region properties
+            #region properties
 
         public EDnsOptionCode Code
         { get { return _code; } }
@@ -147,8 +166,7 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         public EDnsOptionData Data
         { get { return _data; } }
 
-        public int UncompressedLength
-        { get { return 2 + 2 + _data.UncompressedLength; } }
+        public int UncompressedLength => 2 + 2 + (_data?.UncompressedLength ?? 0);
 
         #endregion
     }

--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsOption.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsOption.cs
@@ -82,6 +82,10 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
                     _data = new EDnsExtendedDnsErrorOptionData(s);
                     break;
 
+                case EDnsOptionCode.COOKIE:
+                    _data = new EDnsCookieOptionData(s);
+                    break;
+
                 default:
                     _data = new EDnsUnknownOptionData(s);
                     break;
@@ -96,6 +100,14 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         {
             DnsDatagram.WriteUInt16NetworkOrder((ushort)_code, s);
 
+            // OPTION-LENGTH=0 is valid; represent with null data.
+            if (_data is null)
+            {
+                DnsDatagram.WriteUInt16NetworkOrder(0, s);
+                return;
+            }
+
+            // EDnsOptionData.WriteTo writes OPTION-LENGTH + option bytes.
             _data.WriteTo(s);
         }
 
@@ -132,12 +144,19 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         {
             jsonWriter.WriteStartObject();
 
-            jsonWriter.WriteString("Code", _code.ToString());
-            jsonWriter.WriteString("Length", _data.Length + " bytes");
+            jsonWriter.WriteString(nameof(Code), _code.ToString());
 
-            jsonWriter.WritePropertyName("Data");
-            _data.SerializeTo(jsonWriter);
-
+            if (_data is null)
+            {
+                jsonWriter.WriteString("Length", "0 bytes");
+                jsonWriter.WriteNull(nameof(Data));
+            }
+            else
+            {
+                jsonWriter.WriteString("Length", _data.Length + " bytes");
+                jsonWriter.WritePropertyName(nameof(Data));
+                _data.SerializeTo(jsonWriter);
+            }
             jsonWriter.WriteEndObject();
         }
 
@@ -151,8 +170,7 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         public EDnsOptionData Data
         { get { return _data; } }
 
-        public int UncompressedLength
-        { get { return 2 + 2 + _data.UncompressedLength; } }
+        public int UncompressedLength => 2 + 2 + (_data?.UncompressedLength ?? 0);
 
         #endregion
     }

--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsOption.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsOption.cs
@@ -100,14 +100,6 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         {
             DnsDatagram.WriteUInt16NetworkOrder((ushort)_code, s);
 
-            // OPTION-LENGTH=0 is valid; represent with null data.
-            if (_data is null)
-            {
-                DnsDatagram.WriteUInt16NetworkOrder(0, s);
-                return;
-            }
-
-            // EDnsOptionData.WriteTo writes OPTION-LENGTH + option bytes.
             _data.WriteTo(s);
         }
 
@@ -144,19 +136,12 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         {
             jsonWriter.WriteStartObject();
 
-            jsonWriter.WriteString(nameof(Code), _code.ToString());
+            jsonWriter.WriteString("Code", _code.ToString());
+            jsonWriter.WriteString("Length", _data.Length + " bytes");
 
-            if (_data is null)
-            {
-                jsonWriter.WriteString("Length", "0 bytes");
-                jsonWriter.WriteNull(nameof(Data));
-            }
-            else
-            {
-                jsonWriter.WriteString("Length", _data.Length + " bytes");
-                jsonWriter.WritePropertyName(nameof(Data));
-                _data.SerializeTo(jsonWriter);
-            }
+            jsonWriter.WritePropertyName("Data");
+            _data.SerializeTo(jsonWriter);
+
             jsonWriter.WriteEndObject();
         }
 
@@ -170,7 +155,8 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         public EDnsOptionData Data
         { get { return _data; } }
 
-        public int UncompressedLength => 2 + 2 + (_data?.UncompressedLength ?? 0);
+        public int UncompressedLength
+        { get { return 2 + 2 + _data.UncompressedLength; } }
 
         #endregion
     }

--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsOption.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsOption.cs
@@ -78,12 +78,12 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
                     _data = new EDnsExpireOptionData(s);
                     break;
 
-                case EDnsOptionCode.EXTENDED_DNS_ERROR:
-                    _data = new EDnsExtendedDnsErrorOptionData(s);
-                    break;
-
                 case EDnsOptionCode.COOKIE:
                     _data = new EDnsCookieOptionData(s);
+                    break;
+
+                case EDnsOptionCode.EXTENDED_DNS_ERROR:
+                    _data = new EDnsExtendedDnsErrorOptionData(s);
                     break;
 
                 default:


### PR DESCRIPTION
Adds DNS Cookies support across TechnitiumLibrary EDNS(0) COOKIE parsing, server-side cookie generation/validation, and request/response handling per RFC 7873/9018.