### PR TITLE
Added DNSSEC Negative Trust Anchor (EDE 33)

### DIFF
--- a/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsExtendedDnsErrorOptionData.cs
+++ b/TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsExtendedDnsErrorOptionData.cs
@@ -181,6 +181,11 @@ namespace TechnitiumLibrary.Net.Dns.EDnsOptions
         Synthesized = 29,
 
         /// <summary>
+        /// The resolver applied a configured DNSSEC Negative Trust Anchor.
+        /// </summary>
+        NegativeTrustAnchor = 33,
+
+        /// <summary>
         /// Private Use: indicates too many crypto validations for the response with respect to KeyTrap mitigation.
         /// </summary>
         TooManyCryptoValidations = 49152,


### PR DESCRIPTION
## Summary

Adds `NegativeTrustAnchor = 33` to the `EDnsExtendedDnsErrorCode` enum in `EDnsExtendedDnsErrorOptionData.cs`, so the library can represent and round-trip EDE info-code 33 as registered in the [IANA Extended DNS Error Codes registry](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#extended-dns-error-codes).

## Motivation

Code 33 signals that a resolver suppressed DNSSEC validation for a domain because of a configured Negative Trust Anchor (NTA) — an operator override used to keep resolution working during signing incidents or misconfigurations while validation is temporarily disabled for that zone. Consumers of this library that build or parse EDNS(0) Extended DNS Error options (e.g. resolvers, forwarders, diagnostic tooling) currently have no typed way to emit or recognize this code; it would fall through as an unmapped numeric value.

## Changes

- `TechnitiumLibrary.Net/Dns/EDnsOptions/EDnsExtendedDnsErrorOptionData.cs`: added the `NegativeTrustAnchor = 33` enum member with an XML doc comment describing its meaning, placed after `Synthesized = 29` and before the existing `TooManyCryptoValidations` private-use entry, consistent with the file's existing style and ordering.

This is purely an additive enum entry — no changes to serialization, parsing, or the public surface beyond the new member. Since the underlying type is `ushort` and the option data is read/written as a raw numeric value, no encode/decode logic changes were needed for the new code to round-trip correctly.

## Testing

- Reviewed that the new value follows the same declaration and documentation pattern as the surrounding enum members.
- No behavioral logic was touched; existing serialization for `EDnsExtendedDnsErrorOptionData` already handles arbitrary `ushort` info codes, including previously-unmapped ones, so no new or updated unit tests were required for this change.

